### PR TITLE
Refactor the Hugo theme to use Bootstrap as the primary framework for…

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -19,82 +19,7 @@ body {
   padding: 0;
 }
 
-/* LAYOUT */
-
-.container {
-  max-width: var(--container-md);
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-}
-
 /* CONTENT STYLES */
-
-/* Articles Grid */
-.articles-grid {
-  margin: var(--space-8) 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-6);
-}
-
-@media (min-width: 768px) {
-  .articles-grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: var(--space-8);
-  }
-}
-
-.article-card {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
-  padding: var(--space-6);
-  margin-bottom: var(--space-6);
-  transition: border-color var(--transition-fast);
-}
-
-.article-card:hover {
-  border-color: var(--border-medium);
-}
-
-.article-card h3 {
-  margin: 0 0 var(--space-3) 0;
-  font-size: var(--text-xl);
-  font-weight: var(--font-semibold);
-}
-
-.article-card h3 a {
-  color: var(--text-primary);
-  text-decoration: none;
-  transition: color var(--transition-fast);
-}
-
-.article-card h3 a:hover {
-  color: var(--text-secondary);
-}
-
-.article-card time {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-  margin-bottom: var(--space-3);
-  display: block;
-}
-
-.article-card p {
-  color: var(--text-secondary);
-  margin: 0;
-  line-height: var(--leading-relaxed);
-}
-
-/* Individual Article */
-article {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
-  padding: var(--space-8);
-  margin: var(--space-8) auto;
-  max-width: var(--container-md);
-}
 
 .article-header {
   margin-bottom: var(--space-8);
@@ -286,35 +211,6 @@ article {
   color: var(--text-primary);
 }
 
-/* NAVIGATION */
-
-.main-nav {
-  background: var(--bg-primary);
-  border-bottom: 1px solid var(--border-light);
-  padding: var(--space-4) 0;
-}
-
-.nav-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  gap: var(--space-6);
-  justify-content: center;
-}
-
-.nav-list a {
-  color: var(--text-secondary);
-  text-decoration: none;
-  font-weight: var(--font-medium);
-  transition: color var(--transition-fast);
-}
-
-.nav-list a:hover,
-.nav-list a.active {
-  color: var(--text-primary);
-}
-
 /* PAGINATION */
 
 .pagination {
@@ -376,45 +272,60 @@ article {
   color: var(--text-primary);
 }
 
-/* RESPONSIVE */
+/* THEME CUSTOMIZATIONS FOR BOOTSTRAP */
 
-@media (max-width: 768px) {
-  .container {
-    padding: 0 var(--space-3);
-  }
-  
-  article {
-    padding: var(--space-6);
-    margin: var(--space-6) auto;
-  }
-  
-  .article-header h1 {
-    font-size: var(--text-2xl);
-  }
-  
-  .nav-list {
-    flex-direction: column;
-    gap: var(--space-2);
-    text-align: center;
-  }
-  
-  .article-meta {
-    flex-direction: column;
-    gap: var(--space-2);
-  }
-  
-  .pagination {
-    flex-wrap: wrap;
-    gap: var(--space-2);
-  }
-  
-  .articles-grid {
-    padding: 0 var(--space-3);
-    gap: var(--space-6);
-    grid-template-columns: 1fr;
-  }
-  
-  .article-card h3 {
-    font-size: var(--text-lg);
-  }
+/* Override Bootstrap's default theme colors */
+.bg-light {
+    background-color: var(--bg-primary) !important;
+}
+
+.navbar-light .navbar-brand,
+.navbar-light .navbar-nav .nav-link {
+    color: var(--text-secondary);
+}
+
+.navbar-light .navbar-brand:hover,
+.navbar-light .navbar-nav .nav-link:hover,
+.navbar-light .navbar-nav .nav-link.active {
+    color: var(--text-primary);
+}
+
+.navbar-toggler {
+    border-color: var(--border-light);
+}
+
+.navbar-toggler-icon {
+    background-image: none; /* We will use font-awesome or custom icon instead if needed */
+    /* For now, let's rely on font awesome which is already included */
+}
+
+/* Custom card styles to match the theme */
+.card {
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-light);
+}
+
+.card-title a {
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.card-title a:hover {
+    text-decoration: underline;
+}
+
+.card-text {
+    color: var(--text-secondary);
+}
+
+.card-meta {
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+}
+
+.badge.badge-custom {
+    color: var(--text-secondary);
+    border: 1px solid var(--border-light);
+    background-color: transparent;
+    font-weight: normal;
 }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,7 @@
 {{ define "main" }}
-<div class="container">
-  <div class="row">
-    <!-- Main Content -->
-    <div class="col-lg-8">
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-9">
       <section itemscope itemtype="https://schema.org/Blog">
         <header class="page-header">
           <h1 itemprop="name">Latest Articles</h1>
@@ -13,88 +12,79 @@
           {{ end }}
         </header>
         
-        <div class="articles-grid" role="main" aria-label="Blog posts">
+        <div role="main" aria-label="Blog posts">
           {{ range .Paginator.Pages }}
-          <article class="card article-card" itemscope itemtype="https://schema.org/BlogPosting">
+          <article class="card mb-4" itemscope itemtype="https://schema.org/BlogPosting">
             <div class="card-body">
-              <div class="card-content">
-                <header class="article-header">
-                  <h2 class="card-title">
-                    <a href="{{ .RelPermalink }}" 
-                       itemprop="url"
-                       class="article-link">
-                      <span itemprop="headline">{{ .LinkTitle }}</span>
-                    </a>
-                  </h2>
-                  
-                  <div class="card-meta">
-                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" 
-                          itemprop="datePublished">
-                      <i class="far fa-calendar-alt" aria-hidden="true"></i>
-                      {{ .Date.Format "January 2, 2006" }}
-                    </time>
-                    
-                    {{ with .Params.author }}
-                    <span itemprop="author" itemscope itemtype="https://schema.org/Person">
-                      <i class="far fa-user" aria-hidden="true"></i>
-                      <span itemprop="name">{{ . }}</span>
-                    </span>
-                    {{ end }}
-                    
-                    {{ if .ReadingTime }}
-                    <span>
-                      <i class="far fa-clock" aria-hidden="true"></i>
-                      {{ .ReadingTime }} min read
-                    </span>
-                    {{ end }}
-                  </div>
-                </header>
+              <header class="article-header-condensed">
+                <h2 class="card-title h3">
+                  <a href="{{ .RelPermalink }}"
+                     itemprop="url"
+                     class="text-decoration-none">
+                    <span itemprop="headline">{{ .LinkTitle }}</span>
+                  </a>
+                </h2>
                 
-                <div class="article-excerpt">
-                  <p itemprop="description">{{ .Summary | plainify | truncate 150 "..." }}</p>
-                </div>
-                
-                {{ with .Params.tags }}
-                <div class="article-tags">
-                  {{ range . }}
-                  <a href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}" 
-                     class="badge badge-custom" 
-                     rel="tag"
-                     itemprop="keywords">{{ . }}</a>
+                <div class="card-meta text-muted">
+                  <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}"
+                        itemprop="datePublished">
+                    <i class="far fa-calendar-alt me-1" aria-hidden="true"></i>
+                    {{ .Date.Format "January 2, 2006" }}
+                  </time>
+
+                  {{ with .Params.author }}
+                  <span itemprop="author" itemscope itemtype="https://schema.org/Person" class="ms-3">
+                    <i class="far fa-user me-1" aria-hidden="true"></i>
+                    <span itemprop="name">{{ . }}</span>
+                  </span>
+                  {{ end }}
+
+                  {{ if .ReadingTime }}
+                  <span class="ms-3">
+                    <i class="far fa-clock me-1" aria-hidden="true"></i>
+                    {{ .ReadingTime }} min read
+                  </span>
                   {{ end }}
                 </div>
+              </header>
+
+              <div class="card-text mt-3">
+                <p itemprop="description">{{ .Summary | plainify | truncate 150 "..." }}</p>
+              </div>
+
+              {{ with .Params.tags }}
+              <div class="mt-3">
+                {{ range . }}
+                <a href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}"
+                   class="badge badge-custom text-decoration-none me-1"
+                   rel="tag"
+                   itemprop="keywords">{{ . }}</a>
                 {{ end }}
               </div>
-              
-              <footer class="card-footer">
-                <a href="{{ .RelPermalink }}" 
-                   class="btn btn-primary btn-sm"
-                   aria-label="Read full article: {{ .LinkTitle }}">
-                  Read More
-                  <i class="fas fa-arrow-right ms-2" aria-hidden="true"></i>
-                </a>
-              </footer>
-              
-              <meta itemprop="url" content="{{ .Permalink }}">
+              {{ end }}
             </div>
+
+            <footer class="card-footer bg-transparent border-0 text-end">
+              <a href="{{ .RelPermalink }}"
+                 class="btn btn-sm btn-outline-primary"
+                 aria-label="Read full article: {{ .LinkTitle }}">
+                Read More
+                <i class="fas fa-arrow-right ms-1" aria-hidden="true"></i>
+              </a>
+            </footer>
+
+            <meta itemprop="url" content="{{ .Permalink }}">
           </article>
           {{ end }}
         </div>
         
         {{ if gt .Paginator.TotalPages 1 }}
-        <nav aria-label="Blog pagination" class="pagination-wrapper">
+        <nav aria-label="Blog pagination" class="mt-5">
           {{ template "_internal/pagination.html" . }}
         </nav>
         {{ end }}
       </section>
     </div>
-    
-    <!-- Sidebar -->
-    <aside class="col-lg-4" role="complementary" aria-label="Sidebar">
-      <div class="sidebar-content">
-        {{ partial "ads/sidebar.html" . }}
-      </div>
-    </aside>
   </div>
 </div>
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,17 +1,4 @@
-{{/*
-  Site Footer Component
-  
-  Clean, minimal footer with:
-  - Copyright information
-  - Optional additional footer content
-  - Semantic HTML structure
-  - Responsive design
-  
-  @context {Page} . The current page context
-  @returns {string} HTML footer content
-*/}}
-
-<div class="container footer-container">
+<div class="container py-5">
   <div class="row justify-content-center">
     <div class="col-md-8 text-center">
       
@@ -35,7 +22,7 @@
       
       {{/* Theme attribution (can be removed if desired) */}}
       {{- if not .Site.Params.hide_theme_attribution }}
-      <p class="theme-attribution text-muted small mb-0">
+      <p class="theme-attribution text-muted small mt-2 mb-0">
         Powered by 
         <a href="https://gohugo.io/" 
            target="_blank" 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,94 +1,99 @@
 {{ define "main" }}
-<div class="container">
-  <article itemscope itemtype="https://schema.org/Article">
-    <!-- Article Header -->
-    <header class="article-header">
-      <h1 itemprop="headline">{{ .Title }}</h1>
-      
-      {{ if .Params.description }}
-      <p class="lead article-description" itemprop="description">
-        {{ .Params.description }}
-      </p>
-      {{ end }}
-      
-      <div class="article-meta">
-        <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" itemprop="datePublished">
-          <i class="far fa-calendar-alt" aria-hidden="true"></i>
-          {{ .Date.Format "January 2, 2006" }}
-        </time>
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <article itemscope itemtype="https://schema.org/Article">
+        <!-- Article Header -->
+        <header class="article-header">
+          <h1 itemprop="headline">{{ .Title }}</h1>
+
+          {{ if .Params.description }}
+          <p class="lead article-description" itemprop="description">
+            {{ .Params.description }}
+          </p>
+          {{ end }}
+
+          <div class="article-meta">
+            <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" itemprop="datePublished">
+              <i class="far fa-calendar-alt me-1" aria-hidden="true"></i>
+              {{ .Date.Format "January 2, 2006" }}
+            </time>
+
+            {{ if ne .Date .Lastmod }}
+            <time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" itemprop="dateModified" class="ms-3">
+              <i class="far fa-edit me-1" aria-hidden="true"></i>
+              Updated {{ .Lastmod.Format "January 2, 2006" }}
+            </time>
+            {{ end }}
+
+            {{ with .Params.author }}
+            <span itemprop="author" itemscope itemtype="https://schema.org/Person" class="ms-3">
+              <i class="far fa-user me-1" aria-hidden="true"></i>
+              <span itemprop="name">{{ . }}</span>
+            </span>
+            {{ end }}
+
+            {{ if .ReadingTime }}
+            <span aria-label="Reading time" class="ms-3">
+              <i class="far fa-clock me-1" aria-hidden="true"></i>
+              {{ .ReadingTime }} min read
+            </span>
+            {{ end }}
+          </div>
+
+          {{ with .Params.tags }}
+          <div class="article-tags" role="group" aria-label="Article tags">
+            {{ range . }}
+            <a href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}"
+               class="badge badge-custom text-decoration-none me-1"
+               rel="tag"
+               itemprop="keywords">
+              {{ . }}
+            </a>
+            {{ end }}
+          </div>
+          {{ end }}
+        </header>
         
-        {{ if ne .Date .Lastmod }}
-        <time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" itemprop="dateModified">
-          <i class="far fa-edit" aria-hidden="true"></i>
-          Updated {{ .Lastmod.Format "January 2, 2006" }}
-        </time>
+        <!-- Featured Image -->
+        {{ with .Params.images }}
+        <figure class="article-image text-center my-4">
+          <img src="{{ index . 0 | absURL }}"
+               class="img-fluid rounded"
+               alt="{{ $.Params.image_alt | default $.Title }}"
+               itemprop="image"
+               loading="lazy"
+               width="{{ $.Params.image_width | default 1200 }}"
+               height="{{ $.Params.image_height | default 630 }}">
+          {{ if $.Params.image_caption }}
+          <figcaption class="text-muted small mt-2">{{ $.Params.image_caption }}</figcaption>
+          {{ end }}
+        </figure>
         {{ end }}
         
-        {{ with .Params.author }}
-        <span itemprop="author" itemscope itemtype="https://schema.org/Person">
-          <i class="far fa-user" aria-hidden="true"></i>
-          <span itemprop="name">{{ . }}</span>
-        </span>
-        {{ end }}
+        <!-- Article Content -->
+        <div class="article-content" itemprop="articleBody">
+          {{ .Content }}
+        </div>
         
-        {{ if .ReadingTime }}
-        <span aria-label="Reading time">
-          <i class="far fa-clock" aria-hidden="true"></i>
-          {{ .ReadingTime }} min read
-        </span>
-        {{ end }}
-      </div>
+        <!-- Article Footer -->
+        <footer class="article-footer">
+          <!-- Sharing removed as requested -->
+        </footer>
+
+        <!-- Schema.org Metadata -->
+        <meta itemprop="wordCount" content="{{ .WordCount }}">
+        <meta itemprop="url" content="{{ .Permalink }}">
+      </article>
       
-      {{ with .Params.tags }}
-      <div class="article-tags" role="group" aria-label="Article tags">
-        {{ range . }}
-        <a href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}" 
-           class="badge badge-custom" 
-           rel="tag"
-           itemprop="keywords">
-          {{ . }}
-        </a>
-        {{ end }}
-      </div>
-      {{ end }}
-    </header>
-    
-    <!-- Featured Image -->
-    {{ with .Params.images }}
-    <figure class="article-image">
-      <img src="{{ index . 0 | absURL }}" 
-           alt="{{ $.Params.image_alt | default $.Title }}" 
-           itemprop="image"
-           loading="lazy"
-           width="{{ $.Params.image_width | default 1200 }}"
-           height="{{ $.Params.image_height | default 630 }}">
-      {{ if $.Params.image_caption }}
-      <figcaption>{{ $.Params.image_caption }}</figcaption>
-      {{ end }}
-    </figure>
-    {{ end }}
-    
-    <!-- Article Content -->
-    <div class="article-content" itemprop="articleBody">
-      {{ .Content }}
+      <!-- Navigation -->
+      <nav class="article-navigation mt-5" aria-label="Article navigation">
+        {{ partial "breadcrumbs.html" . }}
+        {{- if .Params.tags }}
+          {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+        {{- end }}
+      </nav>
     </div>
-    
-    <!-- Article Footer -->
-    <footer class="article-footer">
-      <!-- Sharing removed as requested -->
-    </footer>
-    
-    <!-- Schema.org Metadata -->
-    <meta itemprop="wordCount" content="{{ .WordCount }}">
-    <meta itemprop="url" content="{{ .Permalink }}">
-  </article>
-  
-  <!-- Navigation -->
-  <nav class="article-navigation" aria-label="Article navigation">
-    {{ partial "breadcrumbs.html" . }}
-    {{- if .Params.tags }}
-      {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
-    {{- end }}
-  </nav>
+  </div>
 </div>
 {{ end }}


### PR DESCRIPTION
… layout and components.

This change addresses the user's request to fix layout issues, improve responsiveness, and standardize the codebase. After an initial exploration into a BEM-based approach, the direction was changed to use Bootstrap per user feedback.

- Removes conflicting and redundant layout styles from `main.css`.
- Adds theme-specific overrides to `main.css` to customize Bootstrap's components with the project's color scheme and fonts.
- Refactors the homepage and single post templates to use Bootstrap's grid system for a centered, single-column layout.
- Replaces custom-styled article cards with the standard Bootstrap card component.
- Ensures the header and footer correctly use Bootstrap components and utilities.